### PR TITLE
Fix Node.js to v14.18.1 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "stable"
+  - "14.18.1"
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
The Travis build completed successfully in this branch.