### PR TITLE
Align datasources list with AER - December 2022

### DIFF
--- a/public/datasources.json
+++ b/public/datasources.json
@@ -117,7 +117,6 @@
     {"name":"Aurora Energy", "sectors":["energy"], "icon":"https://www.cdr.gov.au/sites/default/files/2022-08/No-logo-available-2.png", "url":"https://cdr.energymadeeasy.gov.au/aurora"},
     {"name":"Besy", "sectors":["energy"], "icon":"https://www.cdr.gov.au/sites/default/files/2022-08/No-logo-available-2.png", "url":"https://cdr.energymadeeasy.gov.au/besy"},
     {"name":"Blue NRG", "sectors":["energy"], "icon":"https://www.cdr.gov.au/sites/default/files/2022-08/No-logo-available-2.png", "url":"https://cdr.energymadeeasy.gov.au/blue-nrg"},
-    {"name":"Bright Spark Power", "sectors":["energy"], "icon":"https://www.cdr.gov.au/sites/default/files/2022-08/No-logo-available-2.png", "url":"https://cdr.energymadeeasy.gov.au/bright-spark"},
     {"name":"Brighte Energy", "sectors":["energy"], "icon":"https://www.cdr.gov.au/sites/default/files/2022-08/No-logo-available-2.png", "url":"https://cdr.energymadeeasy.gov.au/brighte"},
     {"name":"Circular Energy", "sectors":["energy"], "icon":"https://www.cdr.gov.au/sites/default/files/2022-08/No-logo-available-2.png", "url":"https://cdr.energymadeeasy.gov.au/circular"},
     {"name":"CleanCo Queensland", "sectors":["energy"], "icon":"https://www.cdr.gov.au/sites/default/files/2022-08/No-logo-available-2.png", "url":"https://cdr.energymadeeasy.gov.au/cleanco"},


### PR DESCRIPTION
This PR updates `datasources.json` to align with the latest list of endpoints published by AER for Energy PRD: [22 December 2022](https://www.aer.gov.au/system/files/Consumer%20Data%20Right%20-%20Energy%20Retailer%20Base%20URIs%20-%20December%202022.pdf)

The changelog notes that Bright Spark Power was removed from the list of endpoints.

<img width="675" alt="image" src="https://user-images.githubusercontent.com/23213119/210175519-2c7f8ede-1975-4399-8f98-ca9cdec709b3.png">
