### PR TITLE
Fix for overlapping label of energyPrd, changed defaults of filter

### DIFF
--- a/src/components/data-source/DataSource.js
+++ b/src/components/data-source/DataSource.js
@@ -261,17 +261,16 @@ const DataSource = (props) => {
     <AccordionDetails>
       <Grid item xs={1}>
       </Grid>
-      <Grid item xs={11}>
+      <Grid item xs={4}>
       <TextField
         error={!isUrl(dataSource.energyPrd)}
         required={false}
         onChange={handleChange('energyPrd')}
         placeholder='e.g. https://data.holder'
-        value={dataSource.energyPrd}
+        value={dataSource.energyPrd || ''}
         margin='normal'
         fullWidth
         label='AER PRD URL (if needed)'
-        style={{width: '40%'}}
       />
       </Grid>
     </AccordionDetails>

--- a/src/components/data/energy/EnergyPanel.js
+++ b/src/components/data/energy/EnergyPanel.js
@@ -53,8 +53,8 @@ const EnergyPanel = (props) => {
   const {dataSources, savedDataSourcesCount, versionInfo} = props
   const classes = useStyles()
   const [expanded, setExpanded] = React.useState(true)
-  const [effective, setEffective] = React.useState('ALL')
-  const [fuelType, setFuelType] = React.useState('ALL')
+  const [effective, setEffective] = React.useState('CURRENT')
+  const [fuelType, setFuelType] = React.useState('GAS')
   const compare = () => {
     if( /Android|webOS|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
       alert('The screen size is too small! Please use a bigger screen to compare.')


### PR DESCRIPTION
New Filter defaults:

Current for Effective and Gas for Fuel type

This should reduce a bit the response size and time to load.