### PR TITLE
fix(): include EnergyAustralia to overrides

### DIFF
--- a/public/override.json
+++ b/public/override.json
@@ -7,5 +7,10 @@
 		"name": "Origin Energy",
 		"energyPrd": "https://cdr.energymadeeasy.gov.au/origin",
 		"url": "https://public.mydata.cdr.originenergy.com.au"
+	},
+	{
+		"name": "EnergyAustralia",
+		"energyPrd": "https://cdr.energymadeeasy.gov.au/energyaustralia",
+		"url": "https://authncdr.energyaustralia.com.au/"
 	}
 ]


### PR DESCRIPTION
Closes https://github.com/ConsumerDataStandardsAustralia/product-comparator-demo/issues/234

This PR updates the overrides.json file to include AER's EnergyAustralia PRD endpoint