### PR TITLE
Redefine local var in each case block

### DIFF
--- a/src/store/data-source/reducer.js
+++ b/src/store/data-source/reducer.js
@@ -21,26 +21,30 @@ export default function dataSources(state=[], action) {
     case fulfilled(SYNC_DATA_SOURCES):
       persistSavedDataSources(action.payload)
       return action.payload
-    case SAVE_DATA_SOURCE:
-      let dataSources = state.map((dataSource, index) => (index === action.index ? {...action.payload, unsaved: false} : dataSource));
+    case SAVE_DATA_SOURCE: {
+      const dataSources = state.map((dataSource, index) => (index === action.index ? {...action.payload, unsaved: false} : dataSource))
       persistSavedDataSources(dataSources)
       return dataSources
-    case DELETE_DATA_SOURCE:
-      dataSources = [...state]
+    }
+    case DELETE_DATA_SOURCE: {
+      const dataSources = [...state]
       dataSources[action.index].deleted = true
       persistSavedDataSources(dataSources)
       return dataSources
+    }
     case MODIFY_DATA_SOURCE_NAME:
     case MODIFY_DATA_SOURCE_ICON:
-    case ENABLE_DATA_SOURCE:
-      dataSources = state.map((dataSource, index) => (index === action.index ? {...action.payload} : dataSource));
+    case ENABLE_DATA_SOURCE: {
+      const dataSources = state.map((dataSource, index) => (index === action.index ? {...action.payload} : dataSource))
       persistSavedDataSources(dataSources)
       return dataSources
+    }
     case MODIFY_DATA_SOURCE_URL:
-    case MODIFY_DATA_SOURCE_ENERGY_PRD_URL:
-      dataSources = state.map((dataSource, index) => (index === action.index ? {...action.payload, unsaved: true} : dataSource))
+    case MODIFY_DATA_SOURCE_ENERGY_PRD_URL: {
+      const dataSources = state.map((dataSource, index) => (index === action.index ? {...action.payload, unsaved: true} : dataSource))
       persistSavedDataSources(dataSources)
       return dataSources
+    }
     default:
       return state
   }


### PR DESCRIPTION
A recent ES update broke the way the once-defined variables initialise in subsequent switch cases. To safeguard them, wrap the cases in individual blocks that define their own instances of the variables, that can be defined as const in them.