### PR TITLE
Remove concurrency from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-26.04
     permissions:
         contents: write
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
     steps:
         - name: Checkout Repository
           id: checkout


### PR DESCRIPTION
Removed as it was not allowing deployment to proceed